### PR TITLE
feat(rust): add public serializable game types

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -25,8 +25,8 @@
 
 ### 1-3. `types.rs` — 公開型定義
 
-- [ ] `Position`, `GameState`, `GameResult` を `#[derive(Serialize)]` で定義
-- [ ] `GameState.flipped` / `is_pass` の契約コメント付記
+- [x] `Position`, `GameState`, `GameResult` を `#[derive(Serialize)]` で定義
+- [x] `GameState.flipped` / `is_pass` の契約コメント付記
 
 ### 1-4. `game.rs` — ゲーム進行管理
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,6 +1,7 @@
 use wasm_bindgen::prelude::*;
 
 pub mod board;
+pub mod types;
 
 #[wasm_bindgen]
 pub fn wasm_ready() -> bool {

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -1,0 +1,34 @@
+use serde::Serialize;
+
+/// A board coordinate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct Position {
+    pub row: u8,
+    pub col: u8,
+}
+
+/// Public game state returned from WASM APIs.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct GameState {
+    pub board: Vec<u8>,
+    pub current_player: u8,
+    pub black_count: u8,
+    pub white_count: u8,
+    pub is_game_over: bool,
+    /// Contract:
+    /// - `true` when the previous action was a pass.
+    /// - `false` when the previous action was a normal move.
+    pub is_pass: bool,
+    /// Contract:
+    /// - Normal move: list of flipped positions (0..=63).
+    /// - Pass: must be an empty list.
+    pub flipped: Vec<u8>,
+}
+
+/// Final result after game over.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct GameResult {
+    pub winner: u8,
+    pub black_count: u8,
+    pub white_count: u8,
+}


### PR DESCRIPTION
## Summary
- add rust public API types in ust/src/types.rs (Position, GameState, GameResult) with Serialize
- add contract comments for GameState.is_pass and GameState.flipped
- export 	ypes module from ust/src/lib.rs
- mark Phase 1-3 checklist items as done in docs/TASKS.md

## Linked task
- docs/TASKS.md: Phase 1 / 1-3 	ypes.rs - 公開型定義

## Validation
- cargo test --manifest-path rust/Cargo.toml
  - result: 3 passed, 0 failed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved code organization with new type definitions for game state, board positions, and game results to better structure internal game logic.

* **Documentation**
  * Updated project documentation to reflect completion of serialization work and contract specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->