### PR TITLE
ci: add GitHub Pages deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,109 @@
+name: CD
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pages-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: "20"
+  WASM_PACK_VERSION: "v0.14.0"
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust
+
+      - name: Install wasm-pack
+        uses: jetli/wasm-pack-action@v0.4.0
+        with:
+          version: ${{ env.WASM_PACK_VERSION }}
+
+      - name: Install dependencies
+        run: npm --prefix web ci
+
+      - name: Build site
+        run: npm --prefix web run build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: web/dist
+
+      - name: Upload wasm artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wasm-pkg
+          path: web/src/wasm/pkg/reversi_bg.wasm
+          if-no-files-found: error
+          retention-days: 1
+
+  size-gate:
+    name: size-gate
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Download wasm artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: wasm-pkg
+          path: web/src/wasm/pkg
+
+      - name: Check gzip size
+        run: node web/scripts/check-wasm-size.mjs
+
+  deploy:
+    name: deploy
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    needs:
+      - build
+      - size-gate
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -188,7 +188,7 @@
 
 ### 5-2. CD ワークフロー（`.github/workflows/deploy.yml`）
 
-- [ ] ビルド → size-gate → GitHub Pages デプロイ
+- [x] ビルド → size-gate → GitHub Pages デプロイ
 
 ### 5-3. 本番リリース
 


### PR DESCRIPTION
## Summary
- add a GitHub Pages CD workflow for pushes to main
- gate deployment on the WASM gzip size check
- mark Phase 5-2 complete in docs/TASKS.md

## Validation
- npm --prefix web run build
- npm --prefix web run test:wasm-size

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 継続的デプロイメント（CD）ワークフローを導入しました。メインブランチへのプッシュ時に自動的にサイトがビルドされ、GitHub Pagesにデプロイされるようになります。
  * WebAssemblyアーティファクトのサイズチェック機能を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->